### PR TITLE
Fix TypeError on pagination

### DIFF
--- a/lib/flex/template/base.rb
+++ b/lib/flex/template/base.rb
@@ -22,7 +22,8 @@ module Flex
           vars[:params] ||= {}
           page = vars[:page].to_i
           page = 1 unless page > 0
-          vars[:params][:from] = ((page - 1) * vars[:params][:size] || vars[:size] || 10).ceil
+          size = vars[:params][:size] || vars[:size] || 10
+          vars[:params][:from] = ((page - 1) * size).ceil
         end
         vars
       end

--- a/lib/flex/template/base.rb
+++ b/lib/flex/template/base.rb
@@ -20,10 +20,10 @@ module Flex
         vars[:type]  = vars[:type].join(',')  if vars[:type].is_a?(Array)
         if vars[:page]
           vars[:params] ||= {}
+          vars[:params][:size] ||= vars[:size] || 10
           page = vars[:page].to_i
           page = 1 unless page > 0
-          size = vars[:params][:size] || vars[:size] || 10
-          vars[:params][:from] = ((page - 1) * size).ceil
+          vars[:params][:from] = ((page - 1) * vars[:params][:size]).ceil
         end
         vars
       end


### PR DESCRIPTION
`FlexSearch.some_query :page => 1, :size => 10` used to raise "TypeError: nil can't be coerced into Fixnum".

That's because the `:from` computation used to be of the form `(page - 1) * vars[:params][:size] || vars[:size] || 10`, which gets operator precedence wrong: it's parsed the same as `((page - 1) * vars[:params][:size]) || vars[:size] || 10`. So, if `vars[:page]` is specified but `vars[:params][:size]` isn't, we multiply a number by a nil, which raises an error.

We _could_ just apply better grouping, but a new variable declaration is more readable, anyway.
